### PR TITLE
adds smoke to flintlock shots

### DIFF
--- a/code/modules/projectiles/gun/flintlock.dm
+++ b/code/modules/projectiles/gun/flintlock.dm
@@ -26,6 +26,8 @@
 	powder_loaded = FALSE
 	ball_loaded = FALSE
 	rammed = FALSE
+	. = ..()
+	new /obj/effect/particle_effect/smoke/quick(get_turf(src))
 
 /obj/item/gun/flintlock/is_loaded()
 	if(!is_flintlock_loaded())


### PR DESCRIPTION
## About The Pull Request

Muskets and flintlocks now create a small puff of smoke when firing. this is smoke/quick so it's (mostly) just decoration. Can be changed at any later date to hang around longer.

## Why It's Good For The Game

Increased immersion. Looks cooler. Is honestly what I expected when I first fired it.

## Changelog
:cl:
add: Added a smoke effect to musket/flintlocks firing.
/:cl:
